### PR TITLE
[Feature] Managing saved queries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    keen (0.7.4)
+    keen (0.7.5)
       multi_json (~> 1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -139,6 +139,41 @@ Many of there queries can be performed with group by, filters, series and interv
 
 Detailed information on available parameters for each API resource can be found on the [API Technical Reference](https://keen.io/docs/api/reference/).
 
+### Managing saved queries
+
+Managing saved queries require MASTER_ID.
+
+To save a query, instead of calling your query:
+
+```ruby
+Keen.sum("purchases", :target_property => "price")
+```
+call:
+```ruby
+saved_query = Keen::SavedQuery.new('name_of_the_query')
+saved_query.put('sum','purchases', :target_property => "price")  # this send to keen the parameters of the query
+saved_query.result # to get the result
+saved_query.delete # to delete the saved query from Keen
+```
+
+Convenient methods
+
+Get the result of a saved query
+```ruby
+Keen::SavedQuery.result('name_saved_query')
+```
+
+Delete a saved query
+```ruby
+Keen::SavedQuery.delete('name_saved_query')
+
+
+Create a saved query from a query:
+```ruby
+query = Keen::Query.new(query_name, event_collection, params)
+query.saved('name_saved_query) # Save the query in Keen and return a Keen::SavedQuery object
+```
+
 ### Deleting events
 
 The Keen IO API allows you to [delete events](https://keen.io/docs/maintenance/#deleting-event-collections)

--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ To track email opens, simply add an image to your email template that points to 
 
 ### Changelog
 
+##### 0.7.5
++ Use `CGI.escape` instead of `URI.escape` to get accurate URL encoding for certain characters
+
 ##### 0.7.4
 + Add support for deletes (thanks again [cbartlett](https://github.com/cbartlett)!)
 + Allow event collection names for publishing/deleting methods to be symbols

--- a/lib/keen.rb
+++ b/lib/keen.rb
@@ -24,6 +24,13 @@ module Keen
 
   class << self
     extend Forwardable
+    def_delegators :default_client,
+                   :project_id, :project_id=,
+                   :write_key, :write_key=,
+                   :read_key, :read_key=,
+                   :api_url, :api_url=,
+                   :master_key, :master_key=
+
 
     def_delegators :default_client,
                    :publish, :publish_async, :publish_batch,

--- a/lib/keen.rb
+++ b/lib/keen.rb
@@ -26,12 +26,6 @@ module Keen
     extend Forwardable
 
     def_delegators :default_client,
-                   :project_id, :project_id=,
-                   :write_key, :write_key=,
-                   :read_key, :read_key=,
-                   :api_url, :api_url=
-
-    def_delegators :default_client,
                    :publish, :publish_async, :publish_batch,
                    :beacon_url
 
@@ -51,6 +45,10 @@ module Keen
         logger.level = Logger::INFO
         logger
       }.call
+    end
+
+    def config
+      default_client.config
     end
 
     private

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -3,6 +3,8 @@ require 'keen/version'
 require 'keen/client/publishing_methods'
 require 'keen/client/querying_methods'
 require 'keen/client/maintenance_methods'
+require 'keen/helpers'
+require 'keen/config'
 
 require 'openssl'
 require 'multi_json'
@@ -13,25 +15,10 @@ module Keen
     include Keen::Client::PublishingMethods
     include Keen::Client::QueryingMethods
     include Keen::Client::MaintenanceMethods
-
-    attr_accessor :project_id, :write_key, :read_key, :master_key, :api_url
-
-    CONFIG = {
-      :api_url => "https://api.keen.io",
-      :api_version => "3.0",
-      :api_headers => lambda { |authorization, sync_or_async|
-        user_agent = "keen-gem, v#{Keen::VERSION}, #{sync_or_async}"
-        user_agent += ", #{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}"
-        if defined?(RUBY_ENGINE)
-          user_agent += ", #{RUBY_ENGINE}"
-        end
-        { "Content-Type" => "application/json",
-          "User-Agent" => user_agent,
-          "Authorization" => authorization }
-      }
-    }
+    include Keen::Helpers
 
     def initialize(*args)
+
       options = args[0]
       unless options.is_a?(Hash)
         # deprecated, pass a hash of options instead
@@ -42,92 +29,20 @@ module Keen
         }.merge(args[3] || {})
       end
 
-      self.project_id, self.write_key, self.read_key, self.master_key = options.values_at(
+      project_id, write_key, read_key, master_key = options.values_at(
         :project_id, :write_key, :read_key, :master_key)
 
-      self.api_url = options[:api_url] || CONFIG[:api_url]
+      config.project_id = project_id
+      config.write_key = write_key
+      config.read_key = read_key
+      config.master_key = master_key
+
+      config.api_url = options[:api_url] || config.api_url
     end
 
-    private
-
-    def process_response(status_code, response_body)
-      case status_code.to_i
-      when 200..201
-        begin
-          return MultiJson.decode(response_body)
-        rescue
-          Keen.logger.warn("Invalid JSON for response code #{status_code}: #{response_body}")
-          return {}
-        end
-      when 204
-        return true
-      when 400
-        raise BadRequestError.new(response_body)
-      when 401
-        raise AuthenticationError.new(response_body)
-      when 404
-        raise NotFoundError.new(response_body)
-      else
-        raise HttpError.new(response_body)
-      end
-    end
-
-    def ensure_project_id!
-      raise ConfigurationError, "Project ID must be set" unless self.project_id
-    end
-
-    def ensure_write_key!
-      raise ConfigurationError, "Write Key must be set for sending events" unless self.write_key
-    end
-
-    def ensure_master_key!
-      raise ConfigurationError, "Master Key must be set for delete event collections" unless self.master_key
-    end
-
-    def ensure_read_key!
-      raise ConfigurationError, "Read Key must be set for queries" unless self.read_key
-    end
-
-    def api_event_collection_resource_path(event_collection)
-      "/#{api_version}/projects/#{project_id}/events/#{CGI.escape(event_collection.to_s)}"
-    end
-
-    def preprocess_params(params)
-      if params.key?(:filters)
-        params[:filters] = MultiJson.encode(params[:filters])
-      end
-
-      if params.key?(:steps)
-        params[:steps] = MultiJson.encode(params[:steps])
-      end
-
-      if params.key?(:analyses)
-        params[:analyses] = MultiJson.encode(params[:analyses])
-      end
-
-      if params.key?(:timeframe) && params[:timeframe].is_a?(Hash)
-        params[:timeframe] = MultiJson.encode(params[:timeframe])
-      end
-
-      query_params = ""
-      params.each do |param, value|
-        query_params << "#{param}=#{CGI.escape(value)}&"
-      end
-
-      query_params.chop!
-      query_params
-    end
-
-    def method_missing(_method, *args, &block)
-      if config = CONFIG[_method.to_sym]
-        if config.is_a?(Proc)
-          config.call(*args)
-        else
-          config
-        end
-      else
-        super
-      end
+    def config
+      @config ||= Keen::Config.new
     end
   end
+
 end

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -4,6 +4,7 @@ require 'keen/client/publishing_methods'
 require 'keen/client/querying_methods'
 require 'keen/client/maintenance_methods'
 require 'keen/helpers'
+require 'keen/query'
 require 'keen/config'
 
 require 'openssl'

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -44,6 +44,11 @@ module Keen
     def config
       @config ||= Keen::Config.new
     end
+
+    # able to set and get any keys of the config
+    def method_missing(name, *args, &blk)
+      config.send name, *args, &blk
+    end
   end
 
 end

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -89,7 +89,7 @@ module Keen
     end
 
     def api_event_collection_resource_path(event_collection)
-      "/#{api_version}/projects/#{project_id}/events/#{URI.escape(event_collection.to_s)}"
+      "/#{api_version}/projects/#{project_id}/events/#{CGI.escape(event_collection.to_s)}"
     end
 
     def preprocess_params(params)
@@ -111,7 +111,7 @@ module Keen
 
       query_params = ""
       params.each do |param, value|
-        query_params << "#{param}=#{URI.escape(value)}&"
+        query_params << "#{param}=#{CGI.escape(value)}&"
       end
 
       query_params.chop!

--- a/lib/keen/client/maintenance_methods.rb
+++ b/lib/keen/client/maintenance_methods.rb
@@ -16,9 +16,9 @@ module Keen
         query_params = preprocess_params(params) if params != {}
 
         begin
-          response = Keen::HTTP::Sync.new(self.api_url).delete(
+          response = Keen::HTTP::Sync.new(config.api_url).delete(
               :path => [api_event_collection_resource_path(event_collection), query_params].compact.join('?'),
-              :headers => api_headers(self.master_key, "sync"))
+              :headers => config.api_headers(config.master_key, "sync"))
         rescue Exception => http_error
           raise HttpError.new("Couldn't perform delete of #{event_collection} on Keen IO: #{http_error.message}", http_error)
         end

--- a/lib/keen/client/publishing_methods.rb
+++ b/lib/keen/client/publishing_methods.rb
@@ -63,10 +63,10 @@ module Keen
 
         deferrable = EventMachine::DefaultDeferrable.new
 
-        http_client = Keen::HTTP::Async.new(self.api_url)
+        http_client = Keen::HTTP::Async.new(config.api_url)
         http = http_client.post(
           :path => api_event_collection_resource_path(event_collection),
-          :headers => api_headers(self.write_key, "async"),
+          :headers => config.api_headers(config.write_key, "async"),
           :body => MultiJson.encode(properties)
         )
 
@@ -108,7 +108,7 @@ module Keen
       def beacon_url(event_collection, properties)
         json = MultiJson.encode(properties)
         data = [json].pack("m0").tr("+/", "-_").gsub("\n", "")
-        "#{self.api_url}#{api_event_collection_resource_path(event_collection)}?api_key=#{self.write_key}&data=#{data}"
+        "#{config.api_url}#{api_event_collection_resource_path(event_collection)}?api_key=#{config.write_key}&data=#{data}"
       end
 
       private
@@ -116,9 +116,9 @@ module Keen
       def publish_body(path, body, error_method)
         begin
           response = Keen::HTTP::Sync.new(
-            self.api_url).post(
+              config.api_url).post(
               :path => path,
-              :headers => api_headers(self.write_key, "sync"),
+              :headers => config.api_headers(config.write_key, "sync"),
               :body => body)
         rescue Exception => http_error
           raise HttpError.new("HTTP #{error_method} failure: #{http_error.message}", http_error)
@@ -127,7 +127,7 @@ module Keen
       end
 
       def api_events_resource_path
-        "/#{api_version}/projects/#{project_id}/events"
+        "/#{config.api_version}/projects/#{config.project_id}/events"
       end
 
       def check_event_data!(event_collection, properties)

--- a/lib/keen/client/querying_methods.rb
+++ b/lib/keen/client/querying_methods.rb
@@ -161,30 +161,9 @@ module Keen
       private
 
       def query(query_name, event_collection, params)
-        ensure_project_id!
-        ensure_read_key!
-
-        if event_collection
-          params[:event_collection] = event_collection.to_s
-        end
-
-        query_params = preprocess_params(params)
-
-        begin
-          response = Keen::HTTP::Sync.new(self.api_url).get(
-              :path => "#{api_query_resource_path(query_name)}?#{query_params}",
-              :headers => api_headers(self.read_key, "sync"))
-        rescue Exception => http_error
-          raise HttpError.new("Couldn't perform #{query_name} on Keen IO: #{http_error.message}", http_error)
-        end
-
-        response_body = response.body.chomp
-        process_response(response.code, response_body)["result"]
+        Keen::Query.new(query_name, event_collection, params).execute
       end
 
-      def api_query_resource_path(analysis_type)
-        "/#{self.api_version}/projects/#{self.project_id}/queries/#{analysis_type}"
-      end
     end
   end
 end

--- a/lib/keen/client/querying_methods.rb
+++ b/lib/keen/client/querying_methods.rb
@@ -161,7 +161,7 @@ module Keen
       private
 
       def query(query_name, event_collection, params)
-        Keen::Query.new(query_name, event_collection, params).execute
+        Keen::Query.new(query_name, event_collection, params, config).execute
       end
 
     end

--- a/lib/keen/config.rb
+++ b/lib/keen/config.rb
@@ -1,0 +1,44 @@
+module Keen
+  class Config
+    attr_accessor :project_id, :write_key, :read_key, :master_key
+
+    CONFIG = {
+        :api_url => "https://api.keen.io",
+        :api_version => "3.0",
+        :api_headers => lambda { |authorization, sync_or_async|
+          user_agent = "keen-gem, v#{Keen::VERSION}, #{sync_or_async}"
+          user_agent += ", #{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}"
+          if defined?(RUBY_ENGINE)
+            user_agent += ", #{RUBY_ENGINE}"
+          end
+          { "Content-Type" => "application/json",
+            "User-Agent" => user_agent,
+            "Authorization" => authorization }
+        }
+    }
+
+    def initialize
+      @options = CONFIG
+    end
+
+    # able to set and get any keys of the config
+    def method_missing(name, *args, &blk)
+      if name.to_s =~ /=$/
+        if @options.has_key?($`.to_sym)
+          @options[$`.to_sym] = args.first
+        else
+          super
+        end
+      elsif config = @options[name.to_sym]
+        if config.is_a?(Proc)
+          config.call(*args)
+        else
+          config
+        end
+      else
+        super
+      end
+    end
+
+  end
+end

--- a/lib/keen/config.rb
+++ b/lib/keen/config.rb
@@ -18,7 +18,7 @@ module Keen
     }
 
     def initialize
-      @options = CONFIG
+      @options = CONFIG.dup
     end
 
     # able to set and get any keys of the config

--- a/lib/keen/config.rb
+++ b/lib/keen/config.rb
@@ -4,21 +4,24 @@ module Keen
 
     CONFIG = {
         :api_url => "https://api.keen.io",
-        :api_version => "3.0",
-        :api_headers => lambda { |authorization, sync_or_async|
-          user_agent = "keen-gem, v#{Keen::VERSION}, #{sync_or_async}"
-          user_agent += ", #{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}"
-          if defined?(RUBY_ENGINE)
-            user_agent += ", #{RUBY_ENGINE}"
-          end
-          { "Content-Type" => "application/json",
-            "User-Agent" => user_agent,
-            "Authorization" => authorization }
-        }
+        :api_version => "3.0"
     }
 
     def initialize
-      @options = CONFIG.dup
+      @options = {}
+      @options = @options.merge(CONFIG.dup)
+    end
+
+    def api_headers(authorization, sync_or_async)
+      user_agent = "keen-gem, v#{Keen::VERSION}, #{sync_or_async}"
+      user_agent += ", #{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}"
+      if defined?(RUBY_ENGINE)
+        user_agent += ", #{RUBY_ENGINE}"
+      end
+
+        { "Content-Type" => "application/json",
+          "User-Agent" => user_agent,
+          "Authorization" => authorization }
     end
 
     # able to set and get any keys of the config
@@ -29,12 +32,8 @@ module Keen
         else
           super
         end
-      elsif config = @options[name.to_sym]
-        if config.is_a?(Proc)
-          config.call(*args)
-        else
-          config
-        end
+      elsif @options[name.to_sym]
+          @options[name.to_sym]
       else
         super
       end

--- a/lib/keen/helpers.rb
+++ b/lib/keen/helpers.rb
@@ -26,19 +26,19 @@ module Keen
     end
 
     def ensure_project_id!
-      raise ConfigurationError, "Project ID must be set" unless Keen.config.project_id
+      raise ConfigurationError, "Project ID must be set" unless config.project_id
     end
 
     def ensure_write_key!
-      raise ConfigurationError, "Write Key must be set for sending events" unless Keen.config.write_key
+      raise ConfigurationError, "Write Key must be set for sending events" unless config.write_key
     end
 
     def ensure_master_key!
-      raise ConfigurationError, "Master Key must be set for delete event collections" unless Keen.config.master_key
+      raise ConfigurationError, "Master Key must be set for delete event collections" unless config.master_key
     end
 
     def ensure_read_key!
-      raise ConfigurationError, "Read Key must be set for queries" unless Keen.config.read_key
+      raise ConfigurationError, "Read Key must be set for queries" unless config.read_key
     end
 
     def api_event_collection_resource_path(event_collection)
@@ -54,7 +54,7 @@ module Keen
     end
 
     def common_api
-      "/#{Keen.config.api_version}/projects/#{Keen.config.project_id}"
+      "/#{config.api_version}/projects/#{config.project_id}"
     end
 
     def preprocess_params(params)
@@ -81,6 +81,10 @@ module Keen
 
       query_params.chop!
       query_params
+    end
+
+    def config
+      @config ? @config : Keen.config
     end
 
   end

--- a/lib/keen/helpers.rb
+++ b/lib/keen/helpers.rb
@@ -1,0 +1,87 @@
+module Keen
+  module Helpers
+
+    private
+
+    def process_response(status_code, response_body)
+      case status_code.to_i
+        when 200..201
+          begin
+            return MultiJson.decode(response_body)
+          rescue
+            Keen.logger.warn("Invalid JSON for response code #{status_code}: #{response_body}")
+            return {}
+          end
+        when 204
+          return true
+        when 400
+          raise BadRequestError.new(response_body)
+        when 401
+          raise AuthenticationError.new(response_body)
+        when 404
+          raise NotFoundError.new(response_body)
+        else
+          raise HttpError.new(response_body)
+      end
+    end
+
+    def ensure_project_id!
+      raise ConfigurationError, "Project ID must be set" unless Keen.config.project_id
+    end
+
+    def ensure_write_key!
+      raise ConfigurationError, "Write Key must be set for sending events" unless Keen.config.write_key
+    end
+
+    def ensure_master_key!
+      raise ConfigurationError, "Master Key must be set for delete event collections" unless Keen.config.master_key
+    end
+
+    def ensure_read_key!
+      raise ConfigurationError, "Read Key must be set for queries" unless Keen.config.read_key
+    end
+
+    def api_event_collection_resource_path(event_collection)
+      "/#{api_version}/projects/#{project_id}/events/#{CGI.escape(event_collection.to_s)}"
+    end
+
+    def api_query_resource_path(analysis_type)
+      "#{common_api}/queries/#{analysis_type}"
+    end
+
+    def api_saved_queries_resource_path(name)
+      "#{common_api}/saved_queries/#{name}"
+    end
+
+    def common_api
+      "/#{Keen.config.api_version}/projects/#{Keen.config.project_id}"
+    end
+
+    def preprocess_params(params)
+      if params.key?(:filters)
+        params[:filters] = MultiJson.encode(params[:filters])
+      end
+
+      if params.key?(:steps)
+        params[:steps] = MultiJson.encode(params[:steps])
+      end
+
+      if params.key?(:analyses)
+        params[:analyses] = MultiJson.encode(params[:analyses])
+      end
+
+      if params.key?(:timeframe) && params[:timeframe].is_a?(Hash)
+        params[:timeframe] = MultiJson.encode(params[:timeframe])
+      end
+
+      query_params = ""
+      params.each do |param, value|
+        query_params << "#{param}=#{CGI.escape(value)}&"
+      end
+
+      query_params.chop!
+      query_params
+    end
+
+  end
+end

--- a/lib/keen/http.rb
+++ b/lib/keen/http.rb
@@ -29,6 +29,12 @@ module Keen
         @http.get(path, headers)
       end
 
+      def put(options)
+        path, headers, body = options.values_at(
+            :path, :headers, :body)
+        @http.put(path, body, headers)
+      end
+
       def delete(options)
         path, headers = options.values_at(
           :path, :headers)

--- a/lib/keen/query.rb
+++ b/lib/keen/query.rb
@@ -5,7 +5,9 @@ module Keen
     include Keen::Helpers
     attr_reader :params, :query_name
 
-    def initialize(query_name=nil, event_collection=nil, params={})
+    def initialize(query_name=nil, event_collection=nil, params={}, config=Keen.config)
+      @config = config
+
       ensure_project_id!
 
       if event_collection
@@ -27,9 +29,9 @@ module Keen
       body = @params.to_json
 
       begin
-        response = Keen::HTTP::Sync.new(Keen.config.api_url).put(
+        response = Keen::HTTP::Sync.new(@config.api_url).put(
             :path => api_saved_queries_resource_path(name),
-            :headers => Keen.config.api_headers(Keen.config.master_key, 'sync'),
+            :headers => @config.api_headers(@config.master_key, 'sync'),
             :body => body)
       rescue Exception => http_error
         raise HttpError.new("Couldn't save #{@query_name} on Keen IO: #{http_error.message}", http_error)
@@ -47,9 +49,9 @@ module Keen
       ensure_read_key!
 
       begin
-        response = Keen::HTTP::Sync.new(Keen.config.api_url).get(
+        response = Keen::HTTP::Sync.new(@config.api_url).get(
             :path => "#{api_saved_queries_resource_path(name)}/result",
-            :headers => Keen.config.api_headers(Keen.config.read_key, "sync"))
+            :headers => @config.api_headers(@config.read_key, "sync"))
       rescue Exception => http_error
         raise HttpError.new("Couldn't perform #{name} on Keen IO: #{http_error.message}", http_error)
       end
@@ -67,9 +69,9 @@ module Keen
       ensure_master_key!
 
       begin
-        response = Keen::HTTP::Sync.new(Keen.config.api_url).delete(
+        response = Keen::HTTP::Sync.new(@config.api_url).delete(
             :path => api_saved_queries_resource_path(name),
-            :headers => Keen.config.api_headers(Keen.config.master_key, 'sync'))
+            :headers => @config.api_headers(@config.master_key, 'sync'))
       rescue Exception => http_error
         raise HttpError.new("Couldn't delete #{name} on Keen IO: #{http_error.message}", http_error)
       end
@@ -85,9 +87,9 @@ module Keen
       param_query = preprocess_params(@params)
 
       begin
-        response = Keen::HTTP::Sync.new(Keen.config.api_url).get(
+        response = Keen::HTTP::Sync.new(@config.api_url).get(
             :path => "#{api_query_resource_path(@query_name)}?#{param_query}",
-            :headers => Keen.config.api_headers(Keen.config.read_key, "sync"))
+            :headers => @config.api_headers(@config.read_key, "sync"))
       rescue Exception => http_error
         raise HttpError.new("Couldn't perform #{@query_name} on Keen IO: #{http_error.message}", http_error)
       end

--- a/lib/keen/query.rb
+++ b/lib/keen/query.rb
@@ -8,8 +8,6 @@ module Keen
     def initialize(query_name=nil, event_collection=nil, params={}, config=Keen.config)
       @config = config
 
-      ensure_project_id!
-
       if event_collection
         params[:event_collection] = event_collection.to_s
       end
@@ -21,6 +19,7 @@ module Keen
 
     # Save a query in Keen
     def save(name)
+      ensure_project_id!
       ensure_master_key!
 
       @params[:analysis_type] = @query_name
@@ -46,6 +45,7 @@ module Keen
 
     # Return the result of a saved query
     def execute_saved(name)
+      ensure_project_id!
       ensure_read_key!
 
       begin
@@ -66,6 +66,7 @@ module Keen
 
     # Delete a saved query
     def delete(name)
+      ensure_project_id!
       ensure_master_key!
 
       begin

--- a/lib/keen/query.rb
+++ b/lib/keen/query.rb
@@ -1,0 +1,59 @@
+require 'keen/helpers'
+
+module Keen
+  class Query
+    include Keen::Helpers
+    attr_reader :params, :query_name
+
+    def initialize(query_name, event_collection, params)
+      ensure_project_id!
+
+      if event_collection
+        params[:event_collection] = event_collection.to_s
+      end
+
+      @params = params
+      @query_name = query_name
+
+    end
+
+    def save(name)
+      ensure_master_key!
+
+      @params[:analysis_type] = @query_name
+      @params[:query_name] = name
+
+      body = @params.to_json
+
+      begin
+        response = Keen::HTTP::Sync.new(Keen.config.api_url).put(
+            :path => api_saved_queries_resource_path(name),
+            :headers => Keen.config.api_headers(Keen.config.master_key, 'sync'),
+            :body => body)
+      rescue Exception => http_error
+        raise HttpError.new("Couldn't save #{@query_name} on Keen IO: #{http_error.message}", http_error)
+      end
+
+      response.code == "201" ? true : false
+    end
+
+    def execute
+      ensure_read_key!
+
+      param_query = preprocess_params(@params)
+
+      begin
+        response = Keen::HTTP::Sync.new(Keen.config.api_url).get(
+            :path => "#{api_query_resource_path(@query_name)}?#{param_query}",
+            :headers => Keen.config.api_headers(Keen.config.read_key, "sync"))
+      rescue Exception => http_error
+        raise HttpError.new("Couldn't perform #{@query_name} on Keen IO: #{http_error.message}", http_error)
+      end
+
+      response_body = response.body.chomp
+      process_response(response.code, response_body)["result"]
+
+    end
+
+  end
+end

--- a/lib/keen/query.rb
+++ b/lib/keen/query.rb
@@ -1,11 +1,11 @@
 require 'keen/helpers'
-
+require 'keen/saved_query'
 module Keen
   class Query
     include Keen::Helpers
-    attr_reader :params, :query_name
+    attr_reader :params, :analysis_type
 
-    def initialize(query_name=nil, event_collection=nil, params={}, config=Keen.config)
+    def initialize(analysis_type=nil, event_collection=nil, params={}, config=Keen.config)
       @config = config
 
       if event_collection
@@ -13,86 +13,29 @@ module Keen
       end
 
       @params = params
-      @query_name = query_name
+      @analysis_type = analysis_type
 
     end
 
-    # Save a query in Keen
-    def save(name)
-      ensure_project_id!
-      ensure_master_key!
-
-      @params[:analysis_type] = @query_name
-      @params[:query_name] = name
-
-      body = @params.to_json
-
-      begin
-        response = Keen::HTTP::Sync.new(@config.api_url).put(
-            :path => api_saved_queries_resource_path(name),
-            :headers => @config.api_headers(@config.master_key, 'sync'),
-            :body => body)
-      rescue Exception => http_error
-        raise HttpError.new("Couldn't save #{@query_name} on Keen IO: #{http_error.message}", http_error)
-      end
-
-      response.code == "201" ? true : false
-    end
-
-    def self.execute(name)
-      self.new.execute_saved(name)
-    end
-
-    # Return the result of a saved query
-    def execute_saved(name)
-      ensure_project_id!
-      ensure_read_key!
-
-      begin
-        response = Keen::HTTP::Sync.new(@config.api_url).get(
-            :path => "#{api_saved_queries_resource_path(name)}/result",
-            :headers => @config.api_headers(@config.read_key, "sync"))
-      rescue Exception => http_error
-        raise HttpError.new("Couldn't perform #{name} on Keen IO: #{http_error.message}", http_error)
-      end
-
-      response_body = response.body.chomp
-      process_response(response.code, response_body)["result"]
-    end
-
-    def self.delete(name)
-      self.new.delete(name)
-    end
-
-    # Delete a saved query
-    def delete(name)
-      ensure_project_id!
-      ensure_master_key!
-
-      begin
-        response = Keen::HTTP::Sync.new(@config.api_url).delete(
-            :path => api_saved_queries_resource_path(name),
-            :headers => @config.api_headers(@config.master_key, 'sync'))
-      rescue Exception => http_error
-        raise HttpError.new("Couldn't delete #{name} on Keen IO: #{http_error.message}", http_error)
-      end
-
-      response.code == "204" ? true : false
-
+    # return a saved query from this query
+    def saved_query(name)
+      saved = Keen::SavedQuery.new(name, @config)
+      saved.put(@analysis_type, nil, @params) ? saved : false
     end
 
     # Execute a query and return the result
     def execute
+      ensure_project_id!
       ensure_read_key!
 
       param_query = preprocess_params(@params)
 
       begin
         response = Keen::HTTP::Sync.new(@config.api_url).get(
-            :path => "#{api_query_resource_path(@query_name)}?#{param_query}",
+            :path => "#{api_query_resource_path(@analysis_type)}?#{param_query}",
             :headers => @config.api_headers(@config.read_key, "sync"))
       rescue Exception => http_error
-        raise HttpError.new("Couldn't perform #{@query_name} on Keen IO: #{http_error.message}", http_error)
+        raise HttpError.new("Couldn't perform #{@analysis_type} on Keen IO: #{http_error.message}", http_error)
       end
 
       response_body = response.body.chomp

--- a/lib/keen/saved_query.rb
+++ b/lib/keen/saved_query.rb
@@ -1,0 +1,87 @@
+require 'keen/helpers'
+
+module Keen
+  class SavedQuery
+    include Keen::Helpers
+    attr_reader :params, :analysis_type, :name
+
+    def initialize(name, config=Keen.config)
+      @config = config
+      @name = name
+    end
+
+    # Save a query in Keen
+    def put(analysis_type=nil, event_collection=nil, params={})
+      ensure_project_id!
+      ensure_master_key!
+
+      @params = params
+      @analysis_type = analysis_type
+
+      if event_collection
+        params[:event_collection] = event_collection.to_s
+      end
+
+      @params[:analysis_type] = @analysis_type
+      @params[:query_name] = name
+
+      body = @params.to_json
+
+      begin
+        response = Keen::HTTP::Sync.new(@config.api_url).put(
+            :path => api_saved_queries_resource_path(name),
+            :headers => @config.api_headers(@config.master_key, 'sync'),
+            :body => body)
+      rescue Exception => http_error
+        raise HttpError.new("Couldn't save #{@name} on Keen IO: #{http_error.message}", http_error)
+      end
+
+      response_body = response.body.chomp
+      process_response(response.code, response_body)
+    end
+
+    def self.result(name)
+      self.new(name).result
+    end
+
+    # Return the result of a saved query
+    def result
+      ensure_project_id!
+      ensure_read_key!
+
+      begin
+        response = Keen::HTTP::Sync.new(@config.api_url).get(
+            :path => "#{api_saved_queries_resource_path(@name)}/result",
+            :headers => @config.api_headers(@config.read_key, "sync"))
+      rescue Exception => http_error
+        raise HttpError.new("Couldn't perform #{@name} on Keen IO: #{http_error.message}", http_error)
+      end
+
+      response_body = response.body.chomp
+      process_response(response.code, response_body)["result"]
+    end
+
+    def self.delete(name)
+      self.new(name).delete
+    end
+
+    # Delete a saved query
+    def delete
+      ensure_project_id!
+      ensure_master_key!
+
+      begin
+        response = Keen::HTTP::Sync.new(@config.api_url).delete(
+            :path => api_saved_queries_resource_path(@name),
+            :headers => @config.api_headers(@config.master_key, 'sync'))
+      rescue Exception => http_error
+        raise HttpError.new("Couldn't delete #{@name} on Keen IO: #{http_error.message}", http_error)
+      end
+
+      response_body = response.body.chomp
+      process_response(response.code, response_body)
+    end
+
+
+  end
+end

--- a/lib/keen/version.rb
+++ b/lib/keen/version.rb
@@ -1,3 +1,3 @@
 module Keen
-  VERSION = "0.7.4"
+  VERSION = "0.7.5"
 end

--- a/spec/keen/client/maintenance_methods_spec.rb
+++ b/spec/keen/client/maintenance_methods_spec.rb
@@ -10,7 +10,7 @@ describe Keen::Client do
     :api_url => api_url ) }
 
   def delete_url(event_collection, filter_params=nil)
-    "#{api_url}/#{api_version}/projects/#{project_id}/events/#{event_collection}#{filter_params ? "?filters=#{URI.escape(MultiJson.encode(filter_params[:filters]))}" : ""}"
+    "#{api_url}/#{api_version}/projects/#{project_id}/events/#{event_collection}#{filter_params ? "?filters=#{CGI.escape(MultiJson.encode(filter_params[:filters]))}" : ""}"
   end
 
   describe '#delete' do

--- a/spec/keen/client/publishing_methods_spec.rb
+++ b/spec/keen/client/publishing_methods_spec.rb
@@ -37,9 +37,9 @@ describe Keen::Client::PublishingMethods do
     end
 
     it "should url encode the event collection" do
-      stub_keen_post(api_event_collection_resource_url(api_url, "foo%20bar"), 201, "")
+      stub_keen_post(api_event_collection_resource_url(api_url, "foo+bar"), 201, "")
       client.publish("foo bar", event_properties)
-      expect_keen_post(api_event_collection_resource_url(api_url, "foo%20bar"), event_properties, "sync", write_key)
+      expect_keen_post(api_event_collection_resource_url(api_url, "foo+bar"), event_properties, "sync", write_key)
     end
 
     it "should wrap exceptions" do
@@ -137,12 +137,12 @@ describe Keen::Client::PublishingMethods do
         }
       end
 
-      it "should uri encode the event collection" do
-        stub_keen_post(api_event_collection_resource_url(api_url, "foo%20bar"), 201, api_success)
+      it "should url encode the event collection" do
+        stub_keen_post(api_event_collection_resource_url(api_url, "foo+bar"), 201, api_success)
         EM.run {
           client.publish_async("foo bar", event_properties).callback {
             begin
-              expect_keen_post(api_event_collection_resource_url(api_url, "foo%20bar"), event_properties, "async", write_key)
+              expect_keen_post(api_event_collection_resource_url(api_url, "foo+bar"), event_properties, "async", write_key)
             ensure
               EM.stop
             end

--- a/spec/keen/client/querying_methods_spec.rb
+++ b/spec/keen/client/querying_methods_spec.rb
@@ -66,32 +66,32 @@ describe Keen::Client do
         test_query
       end
 
-      it "should encode & escape filters properly" do
+      it "should encode filters properly" do
         filters = [{
           :property_name => "the+animal",
           :operator => "eq",
           :property_value => "dogs"
         }]
-        filter_str = "&filters=%5B%7B%22property_name%22%3A%22the%2Banimal%22%2C%22operator%22%3A%22eq%22%2C%22property_value%22%3A%22dogs%22%7D%5D"
-        test_query(filter_str, :filters => filters)
+        filter_str = CGI.escape(MultiJson.encode(filters))
+        test_query("&filters=#{filter_str}", :filters => filters)
       end
 
-      it "should encode & escape absolute timeframes properly" do
+      it "should encode absolute timeframes properly" do
         timeframe = {
-          :start => "2012-08-13T19:00+00:00",
-          :end => "2012-08-13T19:00+00:00",
+          :start => "2012-08-13T19:00Z+00:00",
+          :end => "2012-08-13T19:00Z+00:00",
         }
-        timeframe_str = "&timeframe=%7B%22start%22%3A%222012-08-13T19%3A00%2B00%3A00%22%2C%22end%22%3A%222012-08-13T19%3A00%2B00%3A00%22%7D"
-        test_query(timeframe_str, :timeframe => timeframe)
+        timeframe_str = CGI.escape(MultiJson.encode(timeframe))
+        test_query("&timeframe=#{timeframe_str}", :timeframe => timeframe)
       end
 
-      it "should encode & escape steps properly" do
+      it "should encode steps properly" do
         steps = [{
-          :event_collection => "sign+ups",
+          :event_collection => "sign ups",
           :actor_property => "user.id"
         }]
-        steps_str = "&steps=%5B%7B%22event_collection%22%3A%22sign%2Bups%22%2C%22actor_property%22%3A%22user.id%22%7D%5D"
-        test_query(steps_str, :steps => steps)
+        steps_str = CGI.escape(MultiJson.encode(steps))
+        test_query("&steps=#{steps_str}", :steps => steps)
       end
 
       it "should not encode relative timeframes" do

--- a/spec/keen/client/querying_methods_spec.rb
+++ b/spec/keen/client/querying_methods_spec.rb
@@ -66,32 +66,32 @@ describe Keen::Client do
         test_query
       end
 
-      it "should encode filters properly" do
+      it "should encode & escape filters properly" do
         filters = [{
-          :property_name => "animal",
+          :property_name => "the+animal",
           :operator => "eq",
           :property_value => "dogs"
         }]
-        filter_str = MultiJson.encode(filters)
-        test_query("&filters=#{filter_str}", :filters => filters)
+        filter_str = "&filters=%5B%7B%22property_name%22%3A%22the%2Banimal%22%2C%22operator%22%3A%22eq%22%2C%22property_value%22%3A%22dogs%22%7D%5D"
+        test_query(filter_str, :filters => filters)
       end
 
-      it "should encode absolute timeframes properly" do
+      it "should encode & escape absolute timeframes properly" do
         timeframe = {
-          :start => "2012-08-13T19:00Z",
-          :end => "2012-08-13T19:00Z",
+          :start => "2012-08-13T19:00+00:00",
+          :end => "2012-08-13T19:00+00:00",
         }
-        timeframe_str = MultiJson.encode(timeframe)
-        test_query("&timeframe=#{timeframe_str}", :timeframe => timeframe)
+        timeframe_str = "&timeframe=%7B%22start%22%3A%222012-08-13T19%3A00%2B00%3A00%22%2C%22end%22%3A%222012-08-13T19%3A00%2B00%3A00%22%7D"
+        test_query(timeframe_str, :timeframe => timeframe)
       end
 
-      it "should encode steps properly" do
+      it "should encode & escape steps properly" do
         steps = [{
-          :event_collection => "signups",
+          :event_collection => "sign+ups",
           :actor_property => "user.id"
         }]
-        steps_str = MultiJson.encode(steps)
-        test_query("&steps=#{steps_str}", :steps => steps)
+        steps_str = "&steps=%5B%7B%22event_collection%22%3A%22sign%2Bups%22%2C%22actor_property%22%3A%22user.id%22%7D%5D"
+        test_query(steps_str, :steps => steps)
       end
 
       it "should not encode relative timeframes" do


### PR DESCRIPTION
### Overview

With the current state of the keen-gem, this is not possible to manage saved queries.
To achieve this we need an object to represent a query, access to settings outside of the client class and share helpers methods.

These modifications should not changed any others current behaviors
### Managing saved queries

Managing saved queries require MASTER_ID.

To save a query, instead of calling your query:

``` ruby
Keen.sum("purchases", :target_property => "price")
```

You need to pass the name of query as the first parameter to the Keen::Query initializer and call the save method on this query:

``` ruby
Keen::Query.new('sum','purchases', :target_property => "price").save('name_of_the_query')
```

To executed a saved query:

``` ruby
Keen::Query.execute('name_saved_query')
```

Create a query:

``` ruby
query = Keen::Query.new(query_name, event_collection, params)
```

Execute the query:

``` ruby
query.execute
```

Save the query:

``` ruby
query.save('name')
```

Delete a query

``` ruby
Keen::Query.delete('name_saved_query')
```
### Other changes

The config variables are now stored in a Config class.
Helpers methods moved to helpers file.
